### PR TITLE
cmake update 2024

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
-# project_VERSION* variables populated from project(... VERSION x.x.x) string
-cmake_policy(SET CMP0048 NEW)
+cmake_minimum_required(VERSION 3.16)
 
 project(libefp VERSION 1.7.2 LANGUAGES C)
 set(libefp_AUTHORS "Ilya A. Kaliman, Lori A. Burns, Dmitry Morozov, Carlos H. Borca, Yen (Terri) Bui, Yongbin Kim, Lyudmila V. Slipchenko")
@@ -37,35 +35,11 @@ find_package(TargetLAPACK REQUIRED)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-set(PN ${PROJECT_NAME})
+set(efp libefp)  # Namespace
 
 # <<< Build >>>
 
-set(raw_sources_list aidisp.c balance.c clapack.c disp.c efp.c elec.c
-                     electerms.c int.c log.c parse.c pol.c poldirect.c
-                     stream.c swf.c util.c xr.c)
-set(src_prefix "src/")
-string(REGEX REPLACE "([^;]+)" "${src_prefix}\\1" sources_list "${raw_sources_list}")
-
-# STATIC/SHARED on below governed by BUILD_SHARED_LIBS
-add_library(efp ${sources_list})
-set_target_properties(efp
-  PROPERTIES
-    POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
-    C_STANDARD 99
-    C_STANDARD_REQUIRED ON
-    C_EXTENSIONS OFF
-    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-  )
-
-if(${BUILD_SHARED_LIBS})
-    target_link_libraries(efp PRIVATE ${LIBC_INTERJECT})
-    if(APPLE)
-        set_target_properties(efp PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-    endif()
-endif()
-target_link_libraries(efp PRIVATE tgt::lapack)
-
+# fragment library
 set(FRAGLIB_DATADIRS "")
 file(GLOB_RECURSE _dotefps RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "fraglib/*.efp")
 foreach(_dotefp ${_dotefps})
@@ -85,28 +59,84 @@ foreach(_dotefp ${_dotefps})
         set(_destcontents ${_strefp})
     endif()
 
-    list(APPEND FRAGLIB_DATADIRS ${_destdir})
+    list(APPEND FRAGLIB_DATADIRS "${_destdir}")
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${_destdir}/${_efpfile} ${_destcontents})
 endforeach()
 list(REMOVE_DUPLICATES FRAGLIB_DATADIRS)
 
+# C library
+set(raw_sources_list
+  aidisp.c
+  balance.c
+  clapack.c
+  disp.c
+  efp.c
+  elec.c
+  electerms.c
+  int.c
+  log.c
+  parse.c
+  pol.c
+  poldirect.c
+  stream.c
+  swf.c
+  util.c
+  xr.c
+  )
+set(src_prefix "src/")
+string(REGEX REPLACE "([^;]+)" "${src_prefix}\\1" sources_list "${raw_sources_list}")
+
+set(export_properties
+  "${efp}_VERSION"
+  "${efp}_FRAGLIB_DIRS"
+  )
+
+# STATIC/SHARED on below governed by BUILD_SHARED_LIBS
+add_library(efp ${sources_list})
+add_library(${efp}::efp ALIAS efp)
+set_target_properties(efp
+  PROPERTIES
+    POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
+    C_STANDARD 99
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    OUTPUT_NAME "efp"
+    EXPORT_NAME "efp"
+    ${efp}_VERSION ${${efp}_VERSION}
+    ${efp}_FRAGLIB_DIRS "${FRAGLIB_DATADIRS}"
+  )
+set_property(TARGET efp APPEND PROPERTY EXPORT_PROPERTIES "${export_properties}")
+
+if(${BUILD_SHARED_LIBS})
+    target_link_libraries(efp PRIVATE ${LIBC_INTERJECT})
+    if(APPLE)
+        set_target_properties(efp PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    endif()
+endif()
+target_link_libraries(
+  efp
+  PUBLIC
+    tgt::lapack
+  )
+
 # <<< Install >>>
 
 install(FILES fraglib/makefp.inp
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/${PN})
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/${efp})
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fraglib
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/${PN})
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/${efp})
 
 # headers NOT namespace protected
 install(FILES ${src_prefix}/efp.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 if (INSTALL_DEVEL_HEADERS)
     install(DIRECTORY ${src_prefix}
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PN}
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${efp}
             FILES_MATCHING PATTERN "*.h")
 endif()
 install(TARGETS efp
-        EXPORT "${PN}Targets"
+        EXPORT "${efp}Targets-C"
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -114,25 +144,38 @@ install(TARGETS efp
 
 # <<< Export Interface >>>
 
-target_compile_definitions(efp INTERFACE USING_${PN})
+target_compile_definitions(efp INTERFACE USING_${efp})
 target_include_directories(efp INTERFACE
                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # <<< Export Config >>>
 
-configure_package_config_file(cmake/${PN}Config.cmake.in
-                              "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
-                              INSTALL_DESTINATION ${LIBEFP_CMAKECONFIG_INSTALL_DIR})
-write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
-                                 VERSION ${${PN}_VERSION}
-                                 COMPATIBILITY SameMinorVersion)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
-              cmake/FindTargetLAPACK.cmake
-        DESTINATION ${LIBEFP_CMAKECONFIG_INSTALL_DIR})
-install(EXPORT "${PN}Targets"
-        NAMESPACE "${PN}::"
-        DESTINATION ${LIBEFP_CMAKECONFIG_INSTALL_DIR})
+configure_package_config_file(
+  cmake/${efp}Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/${efp}Config.cmake"
+  INSTALL_DESTINATION ${LIBEFP_CMAKECONFIG_INSTALL_DIR}
+  )
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/${efp}ConfigVersion.cmake
+  VERSION ${${efp}_VERSION}
+  COMPATIBILITY SameMinorVersion
+  )
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${efp}Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${efp}ConfigVersion.cmake
+    cmake/FindTargetLAPACK.cmake
+  DESTINATION
+    ${LIBEFP_CMAKECONFIG_INSTALL_DIR}
+  )
+install(
+  EXPORT
+    "${efp}Targets-C"
+  NAMESPACE
+    "${efp}::"
+  DESTINATION
+    ${LIBEFP_CMAKECONFIG_INSTALL_DIR}
+  )
 
 # Notes on CMake: CMake builds libefp, the shared or static library,
 #   but not efpmd because Psi4 doesn't use it. Also not implemented

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON "-xHo
 option_with_print(FRAGLIB_UNDERSCORE_L "Installed fragment library has names ending in _L. Psi4 wants OFF" ON)
 option_with_print(FRAGLIB_DEEP "Installed fragment libary has hierarchical, not flat, filestructure. Psi4 wants OFF" ON)
 option_with_print(INSTALL_DEVEL_HEADERS "Install additional namespaced devel headers beyond convenience efp.h" OFF)
+option_with_default(LIBEFP_CMAKECONFIG_INSTALL_DIR "Directory within CMAKE_INSTALL_PREFIX to which CMake configuration files installed" "share/cmake/libefp")
 
 ######################### Process & Validate Options ###########################
 include(autocmake_safeguards)
@@ -48,9 +49,15 @@ string(REGEX REPLACE "([^;]+)" "${src_prefix}\\1" sources_list "${raw_sources_li
 
 # STATIC/SHARED on below governed by BUILD_SHARED_LIBS
 add_library(efp ${sources_list})
-set_target_properties(efp PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
-				     COMPILE_FLAGS "-std=c99"
-				     SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
+set_target_properties(efp
+  PROPERTIES
+    POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
+    C_STANDARD 99
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+  )
+
 if(${BUILD_SHARED_LIBS})
     target_link_libraries(efp PRIVATE ${LIBC_INTERJECT})
     if(APPLE)
@@ -100,6 +107,8 @@ if (INSTALL_DEVEL_HEADERS)
 endif()
 install(TARGETS efp
         EXPORT "${PN}Targets"
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -111,21 +120,19 @@ target_include_directories(efp INTERFACE
 
 # <<< Export Config >>>
 
-# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
-set(CMAKECONFIG_INSTALL_DIR "share/cmake/${PN}")
 configure_package_config_file(cmake/${PN}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
-                              INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+                              INSTALL_DESTINATION ${LIBEFP_CMAKECONFIG_INSTALL_DIR})
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
                                  VERSION ${${PN}_VERSION}
-                                 COMPATIBILITY AnyNewerVersion)
+                                 COMPATIBILITY SameMinorVersion)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
               cmake/FindTargetLAPACK.cmake
-        DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+        DESTINATION ${LIBEFP_CMAKECONFIG_INSTALL_DIR})
 install(EXPORT "${PN}Targets"
         NAMESPACE "${PN}::"
-        DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+        DESTINATION ${LIBEFP_CMAKECONFIG_INSTALL_DIR})
 
 # Notes on CMake: CMake builds libefp, the shared or static library,
 #   but not efpmd because Psi4 doesn't use it. Also not implemented

--- a/cmake/FindTargetLAPACK.cmake
+++ b/cmake/FindTargetLAPACK.cmake
@@ -20,6 +20,8 @@
 #      (skip via CMAKE_DISABLE_FIND_PACKAGE_TargetLAPACK), or
 #  (3) the libraries detected by the usual FindLAPACK.cmake module.
 #
+# libefp specialization
+# * None
 
 set(PN TargetLAPACK)
 
@@ -33,7 +35,7 @@ if (LAPACK_LIBRARIES)
     set_property (TARGET tgt::lapack PROPERTY INTERFACE_LINK_LIBRARIES ${LAPACK_LIBRARIES})
 else()
     # 2nd precedence - target already prepared and findable in TargetLAPACKConfig.cmake
-    if (NOT "${DISABLE_FIND_PACKAGE_${PN}}")
+    if (NOT "${CMAKE_DISABLE_FIND_PACKAGE_${PN}}")
         find_package (TargetLAPACK QUIET CONFIG)
     endif()
     if (TARGET tgt::lapack)

--- a/cmake/autocmake_safeguards.cmake
+++ b/cmake/autocmake_safeguards.cmake
@@ -13,7 +13,7 @@
 #   CMAKE_BUILD_TYPE
 
 if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
-    message(FATAL_ERROR "In-source builds not allowed. Please run CMake from top directory and specify a build directory (e.g., cmake -H. -Bbuild).")
+    message(FATAL_ERROR "In-source builds not allowed. Please run CMake from top directory and specify a build directory (e.g., cmake -S. -Bbuild).")
 endif()
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" cmake_build_type_tolower)
@@ -21,6 +21,7 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" cmake_build_type_toupper)
 
 if(NOT cmake_build_type_tolower STREQUAL "debug" AND
    NOT cmake_build_type_tolower STREQUAL "release" AND
+   NOT cmake_build_type_tolower STREQUAL "minsizerel" AND
    NOT cmake_build_type_tolower STREQUAL "relwithdebinfo")
-    message(FATAL_ERROR "Unknown build type \"${CMAKE_BUILD_TYPE}\". Allowed values are Debug, Release, RelWithDebInfo (case-insensitive).")
+    message(FATAL_ERROR "Unknown build type \"${CMAKE_BUILD_TYPE}\". Allowed values are Debug, Release, RelWithDebInfo, MinSizeRel (case-insensitive).")
 endif()

--- a/cmake/libefpConfig.cmake.in
+++ b/cmake/libefpConfig.cmake.in
@@ -1,31 +1,44 @@
 # libefpConfig.cmake
 # ------------------
 #
-# LIBEFP cmake module.
+# libefp cmake module.
 # This module sets the following variables in your project::
 #
 #   libefp_FOUND - true if libefp and all required components found on the system
+#   libefp_VERSION - libefp version in format Major.Minor.Release. Prefer target variable.
+#   libefp_INCLUDE_DIRS - Directory where efp.h header is located and dependent headers. Prefer targets.
+#   libefp_INCLUDE_DIR - same as DIRS. Prefer targets.
+#   libefp_DEFINITIONS - Definitions to indicate libefp is present, namely USING_libefp. Prefer targets.
+#   libefp_LIBRARIES - libefp library to link against plus any dependent libraries. Prefer targets.
+#   libefp_LIBRARY - libefp library to link against. Prefer targets
+#   libefp_FRAGLIB_DIRS - Directories (list of full paths) where EFP fragments are located. Prefer targets.
+#
+#
+# Target variables::
+#
+# It is preferred to use properties set on the base target rather than using the above variables. ::
+#
 #   libefp_VERSION - libefp version in format Major.Minor.Release
-#   libefp_INCLUDE_DIRS - Directory where libefp header is located.
-#   libefp_INCLUDE_DIR - same as DIRS
-#   libefp_DEFINITIONS - Definitions necessary to use libefp, namely USING_libefp.
-#   libefp_LIBRARIES - libefp library to link against.
-#   libefp_LIBRARY - same as LIBRARIES
-#   libefp_FRAGLIB_DIRS - Directories (list) where EFP fragments are located
+#   libefp_FRAGLIB_DIRS - Directories (list) where EFP fragments are located. Unlike
+#                         the plain variable, this target variable contains partial paths.
+#
+#   get_property(_ver TARGET libefp::efp PROPERTY libefp_VERSION)
 #
 #
-# Available components: shared static ::
+# Available components::
 #
 #   shared - search for only shared library
 #   static - search for only static library
+#   deep - search for only fragment library where directory structure is layered
 #   shallow - search for only fragment library where directory structure has been collapsed
 #
 #
 # Exported targets::
 #
-# If libefp is found, this module defines the following :prop_tgt:`IMPORTED`
-# target. Target is shared _or_ static, so, for both, use separate, not
-# overlapping, installations. ::
+# If libefp is found, this module defines at least the first following
+# :prop_tgt:`IMPORTED` target. Target is shared _or_ static, so, for both, use
+# separate, not overlapping, installations. Depending on components available,
+# it may define::
 #
 #   libefp::efp - the main libefp library with header & defs attached.
 #
@@ -46,99 +59,73 @@
 
 @PACKAGE_INIT@
 
-set(PN libefp)
-set (_valid_components
-    static
-    shared
-    shallow
-)
+set(efp libefp)  # NameSpace
 
-# find includes
-unset(_temp_h CACHE)
-find_path(_temp_h
-          NAMES efp.h
-          PATHS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@
-          NO_DEFAULT_PATH)
-if(_temp_h)
-    set(${PN}_INCLUDE_DIR "${_temp_h}")
-    set(${PN}_INCLUDE_DIRS ${${PN}_INCLUDE_DIR})
+# check library style component
+if (@BUILD_SHARED_LIBS@)  # BUILD_SHARED_LIBS
+    set(${efp}_shared_FOUND 1)
 else()
-    set(${PN}_FOUND 0)
-    if(NOT CMAKE_REQUIRED_QUIET)
-        message(STATUS "${PN}Config missing component: header (${PN}: ${_temp_h})")
-    endif()
+    set(${efp}_static_FOUND 1)
 endif()
 
-# find library: shared, static, or whichever
-set(_hold_library_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
-list(FIND ${PN}_FIND_COMPONENTS "shared" _seek_shared)
-list(FIND ${PN}_FIND_COMPONENTS "static" _seek_static)
-if(_seek_shared GREATER -1)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
-elseif(_seek_static GREATER -1)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
-endif()
-unset(_temp CACHE)
-find_library(_temp
-             NAMES efp
-             PATHS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@
-             NO_DEFAULT_PATH)
-if(_temp)
-    set(${PN}_LIBRARY "${_temp}")
-    if(_seek_shared GREATER -1)
-        set(${PN}_shared_FOUND 1)
-    elseif(_seek_static GREATER -1)
-        set(${PN}_static_FOUND 1)
-    endif()
-else()
-    if(_seek_shared GREATER -1)
-        if(NOT CMAKE_REQUIRED_QUIET)
-            message(STATUS "${PN}Config missing component: shared library (${PN}: ${_temp})")
-        endif()
-    elseif(_seek_static GREATER -1)
-        if(NOT CMAKE_REQUIRED_QUIET)
-            message(STATUS "${PN}Config missing component: static library (${PN}: ${_temp})")
-        endif()
-    else()
-        set(${PN}_FOUND 0)
-        if(NOT CMAKE_REQUIRED_QUIET)
-            message(STATUS "${PN}Config missing component: library (${PN}: ${_temp})")
-        endif()
-    endif()
-endif()
-set(CMAKE_FIND_LIBRARY_SUFFIXES ${_hold_library_suffixes})
-set(${PN}_LIBRARIES ${${PN}_LIBRARY})
-set(${PN}_DEFINITIONS USING_${PN})
+# check library language component
+set(${efp}_C_FOUND 1)
 
 # find fraglibs
-list(FIND ${PN}_FIND_COMPONENTS "shallow" _seek_shallow)
-string(REGEX REPLACE "([^;]+)" "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_DATADIR@/${PN}/\\1" ${PN}_FRAGLIB_DIRS "@FRAGLIB_DATADIRS@")
-if(_seek_shallow GREATER -1)
-    list(LENGTH ${PN}_FRAGLIB_DIRS _temp_len)
-    if(_temp_len EQUAL 1)
-        set(${PN}_shallow_FOUND 1)
-    else()
-        if(NOT CMAKE_REQUIRED_QUIET)
-            message(STATUS "${PN}Config missing component: shallow fraglib (${PN}: ${${PN}_FRAGLIB_DIRS})")
-        endif()
-    endif()
+if (@FRAGLIB_DEEP@)  # FRAGLIB_DEEP
+    set(${efp}_deep_FOUND 1)
+else()
+    set(${efp}_shallow_FOUND 1)
 endif()
+string(REGEX REPLACE "([^;]+)" "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_DATADIR@/${efp}/\\1" ${efp}_FRAGLIB_DIRS "@FRAGLIB_DATADIRS@")  # FRAGLIB_DATADIRS
 
-check_required_components(${PN})
 
 # make detectable the FindTarget*.cmake modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+# check library dependency available
+include(CMakeFindDependencyMacro)
+if(NOT TARGET tgt::lapack)
+    find_dependency(TargetLAPACK)
+endif()
+
+# Check all required components are available before trying to load any
+check_required_components(${efp})
 
 #-----------------------------------------------------------------------------
 # Don't include targets if this file is being picked up by another
 # project which has already built this as a subproject
 #-----------------------------------------------------------------------------
-if(NOT TARGET ${PN}::efp)
-    include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
+if(NOT TARGET ${efp}::efp)
+    include("${CMAKE_CURRENT_LIST_DIR}/${efp}Targets-C.cmake")
 
-    include(CMakeFindDependencyMacro)
-    if(NOT TARGET tgt::lapack)
-        find_dependency(TargetLAPACK)
+    get_property(_loc TARGET ${efp}::efp PROPERTY LOCATION)
+    get_property(_ill TARGET ${efp}::efp PROPERTY INTERFACE_LINK_LIBRARIES)
+    get_property(_iid TARGET ${efp}::efp PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+    get_property(_icd TARGET ${efp}::efp PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+    set(${efp}_LIBRARY ${_loc})
+    set(${efp}_LIBRARIES ${_loc};${_ill})
+    set(${efp}_INCLUDE_DIR ${_iid})
+    set(${efp}_INCLUDE_DIRS ${_iid})
+    set(${efp}_DEFINITIONS ${_icd})
+
+    if (CMAKE_VERSION VERSION_GREATER 3.15)
+        message(VERBOSE "libefp::efp")
+
+        get_property(_ver TARGET ${efp}::efp PROPERTY libefp_VERSION)
+        message(VERBOSE "${efp}::efp.${efp}_VERSION   ${_ver}")
+        get_property(_dir TARGET ${efp}::efp PROPERTY libefp_FRAGLIB_DIRS)
+        message(VERBOSE "${efp}::efp.${efp}_FRAGLIB_DIRS ${_dir}")
+
+        message(VERBOSE "${efp}_FOUND                  ${${efp}_FOUND}")
+        message(VERBOSE "${efp}_VERSION                ${${efp}_VERSION}")
+        message(VERBOSE "${efp}_DEFINITIONS            ${${efp}_DEFINITIONS}")
+        message(VERBOSE "${efp}_FRAGLIB_DIRS           ${${efp}_FRAGLIB_DIRS}")
+
+        message(VERBOSE "${efp}_LIBRARY                ${${efp}_LIBRARY}")
+        message(VERBOSE "${efp}_LIBRARIES              ${${efp}_LIBRARIES}")
+        message(VERBOSE "${efp}_INCLUDE_DIR            ${${efp}_INCLUDE_DIR}")
+        message(VERBOSE "${efp}_INCLUDE_DIRS           ${${efp}_INCLUDE_DIRS}")
     endif()
-endif()
 
+endif()


### PR DESCRIPTION
This collects the CMake changes that have been around for years on my libefp (c. v1.5.0) fork and the set of CMake modernizations that I was rolling out to several projects last year that had their cmake c. 2016. There's no big changes in functionality other than it'll work better with FetchContent. 

If I may have write access, I can add some github actions.