### PR TITLE
help GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,14 +143,13 @@ jobs:
           activate-environment: libefp-dev
           environment-file: export.yaml
           python-version: ${{ matrix.cfg.python-version }}
-          miniforge-variant: Mambaforge
-          use-mamba: true
-          channels: conda-forge,nodefaults
+          channels: conda-forge
+          conda-remove-defaults: true
 
       - name: Environment Information
         run: |
-          mamba info
-          mamba list
+          conda info
+          conda list
 
       - name: Configure CMake
         run: |
@@ -225,7 +224,7 @@ jobs:
       # Step is unnecessary; remove for debugging.
       - name: Confound Environment - test fetched pybind11
         if: ${{ matrix.cfg.blas == 'OBL' }}
-        run: mamba remove pybind11
+        run: conda remove pybind11
 
       - name: Build & Install Python bindings
         run: |


### PR DESCRIPTION
Hi @osu1191 and @slipchenko, this gets the continuous integration checks going a little further. C and Python libraries build fine again, C tests fine, and Python passes about half the tests. (But notably doesn't segfault, so that trouble was probably with your local environment.) All the failing tests are with the polarization term. Maybe your lj and mm additions will  help, Suranjan? I don't see anywhere in #20 (tests seem to have been working before then) when _defaults_ change, which I'd think would be the main thing that would cause terms to break. Hopefully this can help with your debugging. The error in the Windows lane is something different, but I think Linux is first priority.